### PR TITLE
Add `common-celestia-node` chart

### DIFF
--- a/charts/common-celestia-node/.helmignore
+++ b/charts/common-celestia-node/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/common-celestia-node/Chart.yaml
+++ b/charts/common-celestia-node/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: common-celestia-node
+description: A Helm library implementation for celestia-node shared templates
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+# type: application
+type: library
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application and it is recommended to use it with quotes.
+appVersion: "0.17.1"

--- a/charts/common-celestia-node/templates/_bridge_config.toml.tpl
+++ b/charts/common-celestia-node/templates/_bridge_config.toml.tpl
@@ -1,0 +1,74 @@
+{{- define "common-celestia-node.bridge_config.toml" -}}
+[Node]
+  StartupTimeout = "{{ .Values.node.config.bridge.configtoml.Node.StartupTimeout }}"
+  ShutdownTimeout = "{{ .Values.node.config.bridge.configtoml.Node.ShutdownTimeout }}"
+[Core]
+  IP = "{{ .Values.node.config.bridge.configtoml.Core.IP }}"
+  RPCPort = "{{ .Values.node.config.bridge.configtoml.Core.RPCPort }}"
+  GRPCPort = "{{ .Values.node.config.bridge.configtoml.Core.GRPCPort }}"
+[State]
+  DefaultKeyName = "{{ .Values.node.config.bridge.configtoml.State.DefaultKeyName }}"
+  DefaultBackendName = "{{ .Values.node.config.bridge.configtoml.State.DefaultBackendName }}"
+[P2P]
+  ListenAddresses = [{{ range $index, $element := .Values.node.config.bridge.configtoml.P2P.ListenAddresses }}{{ if $index }}, {{ end }}"{{ $element }}"{{ end }}]
+  AnnounceAddresses = {{ .Values.node.config.bridge.configtoml.P2P.AnnounceAddresses }}
+  NoAnnounceAddresses = [{{ range $index, $element := .Values.node.config.bridge.configtoml.P2P.NoAnnounceAddresses }}{{ if $index }}, {{ end }}"{{ $element }}"{{ end }}]
+  MutualPeers = {{ .Values.node.config.bridge.configtoml.P2P.MutualPeers }}
+  PeerExchange = {{ .Values.node.config.bridge.configtoml.P2P.PeerExchange }}
+  RoutingTableRefreshPeriod = "{{ .Values.node.config.bridge.configtoml.P2P.RoutingTableRefreshPeriod }}"
+  [P2P.ConnManager]
+    Low = {{ printf "%.0f" .Values.node.config.bridge.configtoml.P2P.ConnManager.Low }}
+    High = {{ printf "%.0f" .Values.node.config.bridge.configtoml.P2P.ConnManager.High }}
+    GracePeriod = "{{ .Values.node.config.bridge.configtoml.P2P.ConnManager.GracePeriod }}"
+[RPC]
+  Address = "{{ .Values.node.config.bridge.configtoml.RPC.Address }}"
+  Port = "{{ .Values.node.config.bridge.configtoml.RPC.Port }}"
+  SkipAuth = {{ .Values.node.config.bridge.configtoml.RPC.SkipAuth }}
+[Gateway]
+  Address = "{{ .Values.node.config.bridge.configtoml.Gateway.Address }}"
+  Port = "{{ .Values.node.config.bridge.configtoml.Gateway.Port }}"
+  Enabled = {{ .Values.node.config.bridge.configtoml.Gateway.Enabled }}
+[Share]
+  UseShareExchange = {{ .Values.node.config.bridge.configtoml.Share.UseShareExchange }}
+  [Share.EDSStoreParams]
+    GCInterval = "{{ .Values.node.config.bridge.configtoml.Share.EDSStoreParams.GCInterval }}"
+    RecentBlocksCacheSize = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Share.EDSStoreParams.RecentBlocksCacheSize }}
+    BlockstoreCacheSize = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Share.EDSStoreParams.BlockstoreCacheSize }}
+  [Share.ShrExEDSParams]
+    ServerReadTimeout = "{{ .Values.node.config.bridge.configtoml.Share.ShrExEDSParams.ServerReadTimeout }}"
+    ServerWriteTimeout = "{{ .Values.node.config.bridge.configtoml.Share.ShrExEDSParams.ServerWriteTimeout }}"
+    HandleRequestTimeout = "{{ .Values.node.config.bridge.configtoml.Share.ShrExEDSParams.HandleRequestTimeout }}"
+    ConcurrencyLimit = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Share.ShrExEDSParams.ConcurrencyLimit }}
+    BufferSize = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Share.ShrExEDSParams.BufferSize }}
+  [Share.ShrExNDParams]
+    ServerReadTimeout = "{{ .Values.node.config.bridge.configtoml.Share.ShrExNDParams.ServerReadTimeout }}"
+    ServerWriteTimeout = "{{ .Values.node.config.bridge.configtoml.Share.ShrExNDParams.ServerWriteTimeout }}"
+    HandleRequestTimeout = "{{ .Values.node.config.bridge.configtoml.Share.ShrExNDParams.HandleRequestTimeout }}"
+    ConcurrencyLimit = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Share.ShrExNDParams.ConcurrencyLimit }}
+  [Share.PeerManagerParams]
+    PoolValidationTimeout = "{{ .Values.node.config.bridge.configtoml.Share.PeerManagerParams.PoolValidationTimeout }}"
+    PeerCooldown = "{{ .Values.node.config.bridge.configtoml.Share.PeerManagerParams.PeerCooldown }}"
+    GcInterval = "{{ .Values.node.config.bridge.configtoml.Share.PeerManagerParams.GcInterval }}"
+    EnableBlackListing = {{ .Values.node.config.bridge.configtoml.Share.PeerManagerParams.EnableBlackListing }}
+  [Share.Discovery]
+    PeersLimit = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Share.Discovery.PeersLimit }}
+    AdvertiseInterval = "{{ .Values.node.config.bridge.configtoml.Share.Discovery.AdvertiseInterval }}"
+[Header]
+  TrustedHash = "{{ .Values.node.config.bridge.configtoml.Header.TrustedHash }}"
+  TrustedPeers = {{ .Values.node.config.bridge.configtoml.Header.TrustedPeers }}
+  [Header.Store]
+    StoreCacheSize = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Header.Store.StoreCacheSize }}
+    IndexCacheSize = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Header.Store.IndexCacheSize }}
+    WriteBatchSize = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Header.Store.WriteBatchSize }}
+  [Header.Syncer]
+    TrustingPeriod = "{{ .Values.node.config.bridge.configtoml.Header.Syncer.TrustingPeriod }}"
+  [Header.Server]
+    WriteDeadline = "{{ .Values.node.config.bridge.configtoml.Header.Server.WriteDeadline }}"
+    ReadDeadline = "{{ .Values.node.config.bridge.configtoml.Header.Server.ReadDeadline }}"
+    RangeRequestTimeout = "{{ .Values.node.config.bridge.configtoml.Header.Server.RangeRequestTimeout }}"
+  [Header.Client]
+    MaxHeadersPerRangeRequest = {{ printf "%.0f" .Values.node.config.bridge.configtoml.Header.Client.MaxHeadersPerRangeRequest }}
+    RangeRequestTimeout = "{{ .Values.node.config.bridge.configtoml.Header.Client.RangeRequestTimeout }}"
+[Pruner]
+  EnableService = {{ .Values.node.config.bridge.configtoml.Pruner.EnableService }}
+{{- end }}

--- a/charts/common-celestia-node/templates/_configmap.tpl
+++ b/charts/common-celestia-node/templates/_configmap.tpl
@@ -1,0 +1,25 @@
+{{- define "common-celestia-node.configmap" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-configtoml
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels:
+    {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: node
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  config.toml: |
+    {{- if eq .Values.node.settings.nodeType "bridge" -}}
+      {{ include "common-celestia-node.bridge_config.toml" . | nindent 4 }}
+    {{- else if eq .Values.node.settings.nodeType "full" -}}
+      {{ include "common-celestia-node.full_config.toml" . | nindent 4 }}
+    {{- else if eq .Values.node.settings.nodeType "light" -}}
+      {{ include "common-celestia-node.light_config.toml" . | nindent 4 }}
+    {{- else -}}
+      {{ fail "Unsupported nodeType value, must be one of: bridge, full, or light" }}
+    {{- end }}
+{{- end }}

--- a/charts/common-celestia-node/templates/_full_config.toml.tpl
+++ b/charts/common-celestia-node/templates/_full_config.toml.tpl
@@ -1,0 +1,80 @@
+{{- define "common-celestia-node.full_config.toml" -}}
+[Node]
+  StartupTimeout = "{{ .Values.node.config.full.configtoml.Node.StartupTimeout }}"
+  ShutdownTimeout = "{{ .Values.node.config.full.configtoml.Node.ShutdownTimeout }}"
+[Core]
+  IP = "{{ .Values.node.config.full.configtoml.Core.IP }}"
+  RPCPort = "{{ .Values.node.config.full.configtoml.Core.RPCPort }}"
+  GRPCPort = "{{ .Values.node.config.full.configtoml.Core.GRPCPort }}"
+[State]
+  DefaultKeyName = "{{ .Values.node.config.full.configtoml.State.DefaultKeyName }}"
+  DefaultBackendName = "{{ .Values.node.config.full.configtoml.State.DefaultBackendName }}"
+[P2P]
+  ListenAddresses = [{{ range $index, $element := .Values.node.config.full.configtoml.P2P.ListenAddresses }}{{ if $index }}, {{ end }}"{{ $element }}"{{ end }}]
+  AnnounceAddresses = {{ .Values.node.config.full.configtoml.P2P.AnnounceAddresses }}
+  NoAnnounceAddresses = [{{ range $index, $element := .Values.node.config.full.configtoml.P2P.NoAnnounceAddresses }}{{ if $index }}, {{ end }}"{{ $element }}"{{ end }}]
+  MutualPeers = {{ .Values.node.config.full.configtoml.P2P.MutualPeers }}
+  PeerExchange = {{ .Values.node.config.full.configtoml.P2P.PeerExchange }}
+  RoutingTableRefreshPeriod = "{{ .Values.node.config.full.configtoml.P2P.RoutingTableRefreshPeriod }}"
+  [P2P.ConnManager]
+    Low = {{ printf "%.0f" .Values.node.config.full.configtoml.P2P.ConnManager.Low }}
+    High = {{ printf "%.0f" .Values.node.config.full.configtoml.P2P.ConnManager.High }}
+    GracePeriod = "{{ .Values.node.config.full.configtoml.P2P.ConnManager.GracePeriod }}"
+[RPC]
+  Address = "{{ .Values.node.config.full.configtoml.RPC.Address }}"
+  Port = "{{ .Values.node.config.full.configtoml.RPC.Port }}"
+  SkipAuth = {{ .Values.node.config.full.configtoml.RPC.SkipAuth }}
+[Gateway]
+  Address = "{{ .Values.node.config.full.configtoml.Gateway.Address }}"
+  Port = "{{ .Values.node.config.full.configtoml.Gateway.Port }}"
+  Enabled = {{ .Values.node.config.full.configtoml.Gateway.Enabled }}
+[Share]
+  UseShareExchange = {{ .Values.node.config.full.configtoml.Share.UseShareExchange }}
+  [Share.EDSStoreParams]
+    GCInterval = "{{ .Values.node.config.full.configtoml.Share.EDSStoreParams.GCInterval }}"
+    RecentBlocksCacheSize = {{ printf "%.0f" .Values.node.config.full.configtoml.Share.EDSStoreParams.RecentBlocksCacheSize }}
+    BlockstoreCacheSize = {{ printf "%.0f" .Values.node.config.full.configtoml.Share.EDSStoreParams.BlockstoreCacheSize }}
+  [Share.ShrExEDSParams]
+    ServerReadTimeout = "{{ .Values.node.config.full.configtoml.Share.ShrExEDSParams.ServerReadTimeout }}"
+    ServerWriteTimeout = "{{ .Values.node.config.full.configtoml.Share.ShrExEDSParams.ServerWriteTimeout }}"
+    HandleRequestTimeout = "{{ .Values.node.config.full.configtoml.Share.ShrExEDSParams.HandleRequestTimeout }}"
+    ConcurrencyLimit = {{ printf "%.0f" .Values.node.config.full.configtoml.Share.ShrExEDSParams.ConcurrencyLimit }}
+    BufferSize = {{ printf "%.0f" .Values.node.config.full.configtoml.Share.ShrExEDSParams.BufferSize }}
+  [Share.ShrExNDParams]
+    ServerReadTimeout = "{{ .Values.node.config.full.configtoml.Share.ShrExNDParams.ServerReadTimeout }}"
+    ServerWriteTimeout = "{{ .Values.node.config.full.configtoml.Share.ShrExNDParams.ServerWriteTimeout }}"
+    HandleRequestTimeout = "{{ .Values.node.config.full.configtoml.Share.ShrExNDParams.HandleRequestTimeout }}"
+    ConcurrencyLimit = {{ printf "%.0f" .Values.node.config.full.configtoml.Share.ShrExNDParams.ConcurrencyLimit }}
+  [Share.PeerManagerParams]
+    PoolValidationTimeout = "{{ .Values.node.config.full.configtoml.Share.PeerManagerParams.PoolValidationTimeout }}"
+    PeerCooldown = "{{ .Values.node.config.full.configtoml.Share.PeerManagerParams.PeerCooldown }}"
+    GcInterval = "{{ .Values.node.config.full.configtoml.Share.PeerManagerParams.GcInterval }}"
+    EnableBlackListing = {{ .Values.node.config.full.configtoml.Share.PeerManagerParams.EnableBlackListing }}
+  [Share.Discovery]
+    PeersLimit = {{ printf "%.0f" .Values.node.config.full.configtoml.Share.Discovery.PeersLimit }}
+    AdvertiseInterval = "{{ .Values.node.config.full.configtoml.Share.Discovery.AdvertiseInterval }}"
+[Header]
+  TrustedHash = "{{ .Values.node.config.full.configtoml.Header.TrustedHash }}"
+  TrustedPeers = {{ .Values.node.config.full.configtoml.Header.TrustedPeers }}
+  [Header.Store]
+    StoreCacheSize = {{ printf "%.0f" .Values.node.config.full.configtoml.Header.Store.StoreCacheSize }}
+    IndexCacheSize = {{ printf "%.0f" .Values.node.config.full.configtoml.Header.Store.IndexCacheSize }}
+    WriteBatchSize = {{ printf "%.0f" .Values.node.config.full.configtoml.Header.Store.WriteBatchSize }}
+  [Header.Syncer]
+    TrustingPeriod = "{{ .Values.node.config.full.configtoml.Header.Syncer.TrustingPeriod }}"
+  [Header.Server]
+    WriteDeadline = "{{ .Values.node.config.full.configtoml.Header.Server.WriteDeadline }}"
+    ReadDeadline = "{{ .Values.node.config.full.configtoml.Header.Server.ReadDeadline }}"
+    RangeRequestTimeout = "{{ .Values.node.config.full.configtoml.Header.Server.RangeRequestTimeout }}"
+  [Header.Client]
+    MaxHeadersPerRangeRequest = {{ printf "%.0f" .Values.node.config.full.configtoml.Header.Client.MaxHeadersPerRangeRequest }}
+    RangeRequestTimeout = "{{ .Values.node.config.full.configtoml.Header.Client.RangeRequestTimeout }}"
+[DASer]
+  SamplingRange = {{ printf "%.0f" .Values.node.config.full.configtoml.DASer.SamplingRange }}
+  ConcurrencyLimit = {{ printf "%.0f" .Values.node.config.full.configtoml.DASer.ConcurrencyLimit }}
+  BackgroundStoreInterval = "{{ .Values.node.config.full.configtoml.DASer.BackgroundStoreInterval }}"
+  SampleFrom = {{ printf "%.0f" .Values.node.config.full.configtoml.DASer.SampleFrom }}
+  SampleTimeout = "{{ .Values.node.config.full.configtoml.DASer.SampleTimeout }}"
+[Pruner]
+  EnableService = {{ .Values.node.config.full.configtoml.Pruner.EnableService }}
+{{- end }}

--- a/charts/common-celestia-node/templates/_light_config.toml.tpl
+++ b/charts/common-celestia-node/templates/_light_config.toml.tpl
@@ -1,0 +1,82 @@
+{{- define "common-celestia-node.light_config.toml" -}}
+[Node]
+  StartupTimeout = "{{ .Values.node.config.light.configtoml.Node.StartupTimeout }}"
+  ShutdownTimeout = "{{ .Values.node.config.light.configtoml.Node.ShutdownTimeout }}"
+[Core]
+  IP = "{{ .Values.node.config.light.configtoml.Core.IP }}"
+  RPCPort = "{{ .Values.node.config.light.configtoml.Core.RPCPort }}"
+  GRPCPort = "{{ .Values.node.config.light.configtoml.Core.GRPCPort }}"
+[State]
+  DefaultKeyName = "{{ .Values.node.config.light.configtoml.State.DefaultKeyName }}"
+  DefaultBackendName = "{{ .Values.node.config.light.configtoml.State.DefaultBackendName }}"
+[P2P]
+  ListenAddresses = [{{ range $index, $element := .Values.node.config.light.configtoml.P2P.ListenAddresses }}{{ if $index }}, {{ end }}"{{ $element }}"{{ end }}]
+  AnnounceAddresses = {{ .Values.node.config.light.configtoml.P2P.AnnounceAddresses }}
+  NoAnnounceAddresses = [{{ range $index, $element := .Values.node.config.light.configtoml.P2P.NoAnnounceAddresses }}{{ if $index }}, {{ end }}"{{ $element }}"{{ end }}]
+  MutualPeers = {{ .Values.node.config.light.configtoml.P2P.MutualPeers }}
+  PeerExchange = {{ .Values.node.config.light.configtoml.P2P.PeerExchange }}
+  RoutingTableRefreshPeriod = "{{ .Values.node.config.light.configtoml.P2P.RoutingTableRefreshPeriod }}"
+  [P2P.ConnManager]
+    Low = {{ printf "%.0f" .Values.node.config.light.configtoml.P2P.ConnManager.Low }}
+    High = {{ printf "%.0f" .Values.node.config.light.configtoml.P2P.ConnManager.High }}
+    GracePeriod = "{{ .Values.node.config.light.configtoml.P2P.ConnManager.GracePeriod }}"
+[RPC]
+  Address = "{{ .Values.node.config.light.configtoml.RPC.Address }}"
+  Port = "{{ .Values.node.config.light.configtoml.RPC.Port }}"
+  SkipAuth = {{ .Values.node.config.light.configtoml.RPC.SkipAuth }}
+[Gateway]
+  Address = "{{ .Values.node.config.light.configtoml.Gateway.Address }}"
+  Port = "{{ .Values.node.config.light.configtoml.Gateway.Port }}"
+  Enabled = {{ .Values.node.config.light.configtoml.Gateway.Enabled }}
+[Share]
+  UseShareExchange = {{ .Values.node.config.light.configtoml.Share.UseShareExchange }}
+  [Share.EDSStoreParams]
+    GCInterval = "{{ .Values.node.config.light.configtoml.Share.EDSStoreParams.GCInterval }}"
+    RecentBlocksCacheSize = {{ printf "%.0f" .Values.node.config.light.configtoml.Share.EDSStoreParams.RecentBlocksCacheSize }}
+    BlockstoreCacheSize = {{ printf "%.0f" .Values.node.config.light.configtoml.Share.EDSStoreParams.BlockstoreCacheSize }}
+  [Share.ShrExEDSParams]
+    ServerReadTimeout = "{{ .Values.node.config.light.configtoml.Share.ShrExEDSParams.ServerReadTimeout }}"
+    ServerWriteTimeout = "{{ .Values.node.config.light.configtoml.Share.ShrExEDSParams.ServerWriteTimeout }}"
+    HandleRequestTimeout = "{{ .Values.node.config.light.configtoml.Share.ShrExEDSParams.HandleRequestTimeout }}"
+    ConcurrencyLimit = {{ printf "%.0f" .Values.node.config.light.configtoml.Share.ShrExEDSParams.ConcurrencyLimit }}
+    BufferSize = {{ printf "%.0f" .Values.node.config.light.configtoml.Share.ShrExEDSParams.BufferSize }}
+  [Share.ShrExNDParams]
+    ServerReadTimeout = "{{ .Values.node.config.light.configtoml.Share.ShrExNDParams.ServerReadTimeout }}"
+    ServerWriteTimeout = "{{ .Values.node.config.light.configtoml.Share.ShrExNDParams.ServerWriteTimeout }}"
+    HandleRequestTimeout = "{{ .Values.node.config.light.configtoml.Share.ShrExNDParams.HandleRequestTimeout }}"
+    ConcurrencyLimit = {{ printf "%.0f" .Values.node.config.light.configtoml.Share.ShrExNDParams.ConcurrencyLimit }}
+  [Share.PeerManagerParams]
+    PoolValidationTimeout = "{{ .Values.node.config.light.configtoml.Share.PeerManagerParams.PoolValidationTimeout }}"
+    PeerCooldown = "{{ .Values.node.config.light.configtoml.Share.PeerManagerParams.PeerCooldown }}"
+    GcInterval = "{{ .Values.node.config.light.configtoml.Share.PeerManagerParams.GcInterval }}"
+    EnableBlackListing = {{ .Values.node.config.light.configtoml.Share.PeerManagerParams.EnableBlackListing }}
+  [Share.LightAvailability]
+    SampleAmount = {{ printf "%.0f" .Values.node.config.light.configtoml.Share.LightAvailability.SampleAmount }}
+  [Share.Discovery]
+    PeersLimit = {{ printf "%.0f" .Values.node.config.light.configtoml.Share.Discovery.PeersLimit }}
+    AdvertiseInterval = "{{ .Values.node.config.light.configtoml.Share.Discovery.AdvertiseInterval }}"
+[Header]
+  TrustedHash = "{{ .Values.node.config.light.configtoml.Header.TrustedHash }}"
+  TrustedPeers = {{ .Values.node.config.light.configtoml.Header.TrustedPeers }}
+  [Header.Store]
+    StoreCacheSize = {{ printf "%.0f" .Values.node.config.light.configtoml.Header.Store.StoreCacheSize }}
+    IndexCacheSize = {{ printf "%.0f" .Values.node.config.light.configtoml.Header.Store.IndexCacheSize }}
+    WriteBatchSize = {{ printf "%.0f" .Values.node.config.light.configtoml.Header.Store.WriteBatchSize }}
+  [Header.Syncer]
+    TrustingPeriod = "{{ .Values.node.config.light.configtoml.Header.Syncer.TrustingPeriod }}"
+  [Header.Server]
+    WriteDeadline = "{{ .Values.node.config.light.configtoml.Header.Server.WriteDeadline }}"
+    ReadDeadline = "{{ .Values.node.config.light.configtoml.Header.Server.ReadDeadline }}"
+    RangeRequestTimeout = "{{ .Values.node.config.light.configtoml.Header.Server.RangeRequestTimeout }}"
+  [Header.Client]
+    MaxHeadersPerRangeRequest = {{ printf "%.0f" .Values.node.config.light.configtoml.Header.Client.MaxHeadersPerRangeRequest }}
+    RangeRequestTimeout = "{{ .Values.node.config.light.configtoml.Header.Client.RangeRequestTimeout }}"
+[DASer]
+  SamplingRange = {{ printf "%.0f" .Values.node.config.light.configtoml.DASer.SamplingRange }}
+  ConcurrencyLimit = {{ printf "%.0f" .Values.node.config.light.configtoml.DASer.ConcurrencyLimit }}
+  BackgroundStoreInterval = "{{ .Values.node.config.light.configtoml.DASer.BackgroundStoreInterval }}"
+  SampleFrom = {{ printf "%.0f" .Values.node.config.light.configtoml.DASer.SampleFrom }}
+  SampleTimeout = "{{ .Values.node.config.light.configtoml.DASer.SampleTimeout }}"
+[Pruner]
+  EnableService = {{ .Values.node.config.light.configtoml.Pruner.EnableService }}
+{{- end }}


### PR DESCRIPTION
Instead of `generating` the `config.toml` used by the `nodeType` configmap within the `main` helm-chart `celestia-node` we delegate that responsibility to `common-celestia-node` which is a `helm` library chart that enables `modularity`. Ideally everything should be broken down into `reusable` modular blocks. 

After the first release of `common-node-type` we can fully remove the 3 existing configmaps:

1. **configmap-bridge.yaml**
2. **configmap-full.yaml**
3. **configmap-light.yaml**

And have a single `configmap.yaml` that would simply contain the `generator` helper function from `common-celestia-node`

```{{ include "common-celestia-node.configmap" . }}```

main `Chart.yaml` configuration should be changed as:

```
annotations:
  category: celestia
  licenses: Apache-2.0
apiVersion: v2
appVersion: v0.17.1
dependencies:
- name: common
  repository: oci://registry-1.docker.io/bitnamicharts
  tags:
  - bitnami-common
  version: 2.x.x
- name: common-celestia-node
  version: 0.1.0
  repository: https://celestiaorg.github.io/helm-charts
description: Celestia Node
home: https://celestia.org
icon: https://celestia.org/static/celestia-logo-29451ae35d3bb72cc4b0f17712d44c3a.svg
keywords:
  - celestia
  - celestia-node
maintainers:
  - name: Celestia Labs
    url: https://github.com/celestiaorg
name: celestia-node
sources:
  - https://github.com/celestiaorg/helm-charts
version: 0.8.0
```

# Visual diagram

<img width="535" alt="Screenshot 2024-10-16 at 16 24 12" src="https://github.com/user-attachments/assets/a76aabfb-6820-40e6-925a-f34997e3337d">