### PR TITLE
Helm release workflow logic

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -7,7 +7,10 @@ on:
   workflow_dispatch:
 
 jobs:
+  # common-celestia-node
   release-common-celestia-node:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,8 +30,10 @@ jobs:
           packages_with_index: "true"
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
+  # celestia-node
   release-celestia-node:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: release-common-celestia-node
     steps:


### PR DESCRIPTION
Insures the `common-celestia-node` release is done before `celestia-node` since the first is a dependency of the second.