### PR TITLE
fix(node): bump ci to fix the issue

### DIFF
--- a/.github/workflows/release-node.yaml
+++ b/.github/workflows/release-node.yaml
@@ -73,6 +73,11 @@ jobs:
         run: |
           helm dependency update charts/celestia-node
 
+      - name: Prepare charts directory
+        run: |
+          mkdir -p /tmp/charts-backup
+          mv charts/celestia-app /tmp/charts-backup/
+          
       - name: Run chart-releaser for celestia-node
         uses: helm/chart-releaser-action@v1.6.0
         with:
@@ -80,3 +85,8 @@ jobs:
           packages_with_index: "true"
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          
+      - name: Restore charts directory
+        if: always()
+        run: |
+          mv /tmp/charts-backup/celestia-app charts/


### PR DESCRIPTION
because of errors like this:
https://github.com/celestiaorg/helm-charts/actions/runs/12889653566/job/35937522411


```
Run helm/chart-releaser-action@v1.6.0
Run owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
Looking up latest tag...
Discovering changed charts since 'celestia-app-0.0.4'...
Installing chart-releaser on /opt/hostedtoolcache/cr/v1.6.1/x86_64...
Adding cr directory to PATH...
Packaging chart 'charts/celestia-app'...
Error: the lock file (Chart.lock) is out of sync with the dependencies file (Chart.yaml). Please update the dependencies
Usage:
  cr package [CHART_PATH] [...] [flags]

Flags:
  -h, --help                     help for package
      --key string               Name of the key to use when signing
      --keyring string           Location of a public keyring (default "~/.gnupg/pubring.gpg")
  -p, --package-path string      Path to directory with chart packages (default ".cr-release-packages")
      --passphrase-file string   Location of a file which contains the passphrase for the signing key. Use '-' in order to read from stdin
      --sign                     Use a PGP private key to sign this package

Global Flags:
      --config string   Config file (default is $HOME/.cr.yaml)
```